### PR TITLE
Handle moving of the bootstrap file to provide backwards compatibility for the migration period

### DIFF
--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -1,0 +1,5 @@
+# Deprecation Notice
+
+This file (bootstrap/app.php) is deprecated as of v0.35.x as it has been moved to app/bootstrap.php.
+
+The file is preserved for backwards compatibility.

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Create The Application
+|--------------------------------------------------------------------------
+|
+| The first thing we will do is create a new Laravel application instance
+| which serves as the "glue" for all the components of Laravel, and is
+| the IoC container for the system binding all of the various parts.
+|
+*/
+
+$app = new LaravelZero\Framework\Application(
+    dirname(__DIR__)
+);
+
+/*
+|--------------------------------------------------------------------------
+| Bind Important Interfaces
+|--------------------------------------------------------------------------
+|
+| Next, we need to bind some important interfaces into the container so
+| we will be able to resolve them when needed. The kernels serve the
+| incoming requests to this application from both the web and CLI.
+|
+*/
+
+$app->singleton(
+    Illuminate\Contracts\Console\Kernel::class,
+    LaravelZero\Framework\Kernel::class
+);
+
+$app->singleton(
+    Illuminate\Contracts\Debug\ExceptionHandler::class,
+    Illuminate\Foundation\Exceptions\Handler::class
+);
+
+/*
+|--------------------------------------------------------------------------
+| Set Important Hyde Configurations
+|--------------------------------------------------------------------------
+|
+| Next, we need to configure Hyde to to use our project's base path.
+|
+*/
+
+\Hyde\Framework\Hyde::setBasePath(getcwd());
+
+/*
+|--------------------------------------------------------------------------
+| Return The Application
+|--------------------------------------------------------------------------
+|
+| This script returns the application instance. The instance is given to
+| the calling script so we can separate the building of the instances
+| from the actual running of the application and sending responses.
+|
+*/
+
+return $app;

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * @deprecated v0.35.x-dev - This file has moved to app/bootstrap.php,
+ *                           and will be removed in a future release.
+ */
+
 /*
 |--------------------------------------------------------------------------
 | Create The Application

--- a/packages/realtime-compiler/src/Concerns/InteractsWithLaravel.php
+++ b/packages/realtime-compiler/src/Concerns/InteractsWithLaravel.php
@@ -16,7 +16,25 @@ trait InteractsWithLaravel
 
     protected function createApplication(): void
     {
-        $this->laravel = require_once sprintf('%s/bootstrap/app.php', BASE_PATH);
+        // The core bootstrapping file was moved in hyde/framework v0.35.x.
+        // To preserve backwards compatibility, we will continue to load
+        // the old bootstrap file for several minor versions.
+
+        $legacyBootstrapper = sprintf('%s/bootstrap/app.php', BASE_PATH);
+        $bootstrapper = sprintf('%s/app/bootstrap.php', BASE_PATH);
+        if (file_exists($legacyBootstrapper) && !file_exists($bootstrapper)) {
+            trigger_error(
+                sprintf(
+                    'The "%s" file is deprecated since hyde/framework:v0.35.x Please use "%s" instead.',
+                    $legacyBootstrapper,
+                    $bootstrapper
+                ),
+                E_USER_DEPRECATED
+            );
+            $bootstrapper = $legacyBootstrapper;
+        }
+
+        $this->laravel = require_once $bootstrapper;
     }
 
     protected function bootApplication(): void


### PR DESCRIPTION
Provides backwards compatibility by giving a grace period to migrate old projects to handle the breaking move of bootstrap/app.php to app/bootstrap.php in https://github.com/caendesilva/hyde-monorepo/commit/f08c97964a10d1e66b6e50ba91b82d30cb05ac28.

 The PR adds back the legacy file, but with a deprecation notice. It also updates the HydeRC to fix https://github.com/caendesilva/hyde-monorepo/issues/13.
